### PR TITLE
Add user-scoped categories and password ownership controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This service is designed to integrate seamlessly with Vault Web, **sharing its P
 
 - 🔹 CRUD operations for passwords and categories  
 - 🔹 Secure storage of encrypted passwords  
+- 🔹 Tenant-aware storage keyed to the authenticated Vault Web user  
 - 🔹 Access via JWT authentication using Vault Web's master key  
 - 🔹 REST API for integration with web or mobile apps  
 

--- a/backend/src/main/java/com/vaultweb/passwordmanager/backend/controllers/CategoryController.java
+++ b/backend/src/main/java/com/vaultweb/passwordmanager/backend/controllers/CategoryController.java
@@ -1,0 +1,62 @@
+package com.vaultweb.passwordmanager.backend.controllers;
+
+import com.vaultweb.passwordmanager.backend.model.dtos.CategoryDto;
+import com.vaultweb.passwordmanager.backend.security.AuthenticatedUser;
+import com.vaultweb.passwordmanager.backend.services.CategoryService;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/categories")
+@RequiredArgsConstructor
+public class CategoryController {
+
+  private final CategoryService service;
+
+  @PostMapping
+  public ResponseEntity<CategoryDto> create(
+      @AuthenticationPrincipal AuthenticatedUser user,
+      @Valid @RequestBody CategoryDto dto) {
+    CategoryDto created = service.create(dto, user.userId());
+    return ResponseEntity.created(URI.create("/api/categories/" + created.getId())).body(created);
+  }
+
+  @GetMapping
+  public ResponseEntity<List<CategoryDto>> getAll(
+      @AuthenticationPrincipal AuthenticatedUser user) {
+    return ResponseEntity.ok(service.getAll(user.userId()));
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<CategoryDto> getById(
+      @AuthenticationPrincipal AuthenticatedUser user, @PathVariable Long id) {
+    return ResponseEntity.ok(service.get(id, user.userId()));
+  }
+
+  @PutMapping("/{id}")
+  public ResponseEntity<CategoryDto> update(
+      @AuthenticationPrincipal AuthenticatedUser user,
+      @PathVariable Long id,
+      @Valid @RequestBody CategoryDto dto) {
+    return ResponseEntity.ok(service.update(id, user.userId(), dto));
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> delete(
+      @AuthenticationPrincipal AuthenticatedUser user, @PathVariable Long id) {
+    service.delete(id, user.userId());
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/backend/src/main/java/com/vaultweb/passwordmanager/backend/controllers/PasswordEntryController.java
+++ b/backend/src/main/java/com/vaultweb/passwordmanager/backend/controllers/PasswordEntryController.java
@@ -2,12 +2,14 @@ package com.vaultweb.passwordmanager.backend.controllers;
 
 import com.vaultweb.passwordmanager.backend.model.PasswordEntry;
 import com.vaultweb.passwordmanager.backend.model.dtos.PasswordEntryDto;
+import com.vaultweb.passwordmanager.backend.security.AuthenticatedUser;
 import com.vaultweb.passwordmanager.backend.services.PasswordEntryService;
 import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -26,8 +28,10 @@ public class PasswordEntryController {
    *     resource.
    */
   @PostMapping
-  public ResponseEntity<PasswordEntryDto> create(@Valid @RequestBody PasswordEntryDto dto) {
-    PasswordEntry created = service.create(new PasswordEntry(dto));
+  public ResponseEntity<PasswordEntryDto> create(
+      @AuthenticationPrincipal AuthenticatedUser user,
+      @Valid @RequestBody PasswordEntryDto dto) {
+    PasswordEntry created = service.create(new PasswordEntry(dto), user.userId(), dto.getCategoryId());
     return ResponseEntity.created(URI.create("/api/passwords/" + created.getId()))
         .body(new PasswordEntryDto(created));
   }
@@ -39,8 +43,10 @@ public class PasswordEntryController {
    *     password entries.
    */
   @GetMapping
-  public ResponseEntity<List<PasswordEntryDto>> getAll() {
-    List<PasswordEntryDto> dtos = service.getAll().stream().map(PasswordEntryDto::new).toList();
+  public ResponseEntity<List<PasswordEntryDto>> getAll(
+      @AuthenticationPrincipal AuthenticatedUser user) {
+    List<PasswordEntryDto> dtos =
+        service.getAll(user.userId()).stream().map(PasswordEntryDto::new).toList();
     return ResponseEntity.ok(dtos);
   }
 
@@ -52,9 +58,10 @@ public class PasswordEntryController {
    *     404 status if not found
    */
   @GetMapping("/{id}")
-  public ResponseEntity<PasswordEntryDto> getById(@PathVariable Long id) {
+  public ResponseEntity<PasswordEntryDto> getById(
+      @AuthenticationPrincipal AuthenticatedUser user, @PathVariable Long id) {
     return service
-        .getById(id)
+        .getById(id, user.userId())
         .map(entry -> ResponseEntity.ok(new PasswordEntryDto(entry)))
         .orElse(ResponseEntity.notFound().build());
   }
@@ -69,8 +76,11 @@ public class PasswordEntryController {
    */
   @PutMapping("/{id}")
   public ResponseEntity<PasswordEntryDto> update(
-      @PathVariable Long id, @Valid @RequestBody PasswordEntryDto dto) {
-    PasswordEntry updated = service.update(id, new PasswordEntry(dto));
+      @AuthenticationPrincipal AuthenticatedUser user,
+      @PathVariable Long id,
+      @Valid @RequestBody PasswordEntryDto dto) {
+    PasswordEntry updated =
+        service.update(id, new PasswordEntry(dto), user.userId(), dto.getCategoryId());
     return ResponseEntity.ok(new PasswordEntryDto(updated));
   }
 
@@ -81,8 +91,9 @@ public class PasswordEntryController {
    * @return a ResponseEntity with no content if the deletion is successful
    */
   @DeleteMapping("/{id}")
-  public ResponseEntity<Void> delete(@PathVariable Long id) {
-    service.delete(id);
+  public ResponseEntity<Void> delete(
+      @AuthenticationPrincipal AuthenticatedUser user, @PathVariable Long id) {
+    service.delete(id, user.userId());
     return ResponseEntity.noContent().build();
   }
 }

--- a/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/Category.java
+++ b/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/Category.java
@@ -1,0 +1,47 @@
+package com.vaultweb.passwordmanager.backend.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "categories")
+public class Category {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @NotNull(message = "Owner is required")
+  @Column(name = "owner_id", nullable = false)
+  private Long ownerId;
+
+  @NotBlank(message = "Category name is required")
+  @Size(max = 60)
+  private String name;
+
+  @Size(max = 7)
+  private String color;
+
+  @Size(max = 200)
+  private String description;
+
+  @CreationTimestamp private LocalDateTime createdAt;
+
+  @UpdateTimestamp private LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/PasswordEntry.java
+++ b/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/PasswordEntry.java
@@ -5,15 +5,19 @@ import com.vaultweb.passwordmanager.backend.security.AttributeEncryptor;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.ToString;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -44,6 +48,14 @@ public class PasswordEntry {
 
   @Column(length = 500)
   private String notes;
+
+  @Column(name = "owner_id", nullable = false)
+  private Long ownerId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "category_id")
+  @ToString.Exclude
+  private Category category;
 
   @CreationTimestamp private LocalDateTime createdAt;
 

--- a/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/dtos/CategoryDto.java
+++ b/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/dtos/CategoryDto.java
@@ -1,0 +1,33 @@
+package com.vaultweb.passwordmanager.backend.model.dtos;
+
+import com.vaultweb.passwordmanager.backend.model.Category;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryDto {
+
+  private Long id;
+
+  @NotBlank(message = "Category name is required")
+  @Size(max = 60)
+  private String name;
+
+  @Size(max = 7, message = "Color must be a hex value like #AABBCC")
+  private String color;
+
+  @Size(max = 200)
+  private String description;
+
+  public CategoryDto(Category category) {
+    this.id = category.getId();
+    this.name = category.getName();
+    this.color = category.getColor();
+    this.description = category.getDescription();
+  }
+}

--- a/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/dtos/PasswordEntryDto.java
+++ b/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/dtos/PasswordEntryDto.java
@@ -29,6 +29,8 @@ public class PasswordEntryDto {
   @Size(max = 500)
   private String notes;
 
+  private Long categoryId;
+
   public PasswordEntryDto(PasswordEntry entry) {
     this.id = entry.getId();
     this.name = entry.getName();
@@ -36,5 +38,7 @@ public class PasswordEntryDto {
     this.password = entry.getPassword();
     this.url = entry.getUrl();
     this.notes = entry.getNotes();
+    this.categoryId =
+        entry.getCategory() != null ? entry.getCategory().getId() : null;
   }
 }

--- a/backend/src/main/java/com/vaultweb/passwordmanager/backend/repositories/CategoryRepository.java
+++ b/backend/src/main/java/com/vaultweb/passwordmanager/backend/repositories/CategoryRepository.java
@@ -1,0 +1,13 @@
+package com.vaultweb.passwordmanager.backend.repositories;
+
+import com.vaultweb.passwordmanager.backend.model.Category;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+  List<Category> findAllByOwnerId(Long ownerId);
+
+  Optional<Category> findByIdAndOwnerId(Long id, Long ownerId);
+}

--- a/backend/src/main/java/com/vaultweb/passwordmanager/backend/repositories/PasswordEntryRepository.java
+++ b/backend/src/main/java/com/vaultweb/passwordmanager/backend/repositories/PasswordEntryRepository.java
@@ -1,6 +1,13 @@
 package com.vaultweb.passwordmanager.backend.repositories;
 
 import com.vaultweb.passwordmanager.backend.model.PasswordEntry;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PasswordEntryRepository extends JpaRepository<PasswordEntry, Long> {}
+public interface PasswordEntryRepository extends JpaRepository<PasswordEntry, Long> {
+
+	List<PasswordEntry> findAllByOwnerId(Long ownerId);
+
+	Optional<PasswordEntry> findByIdAndOwnerId(Long id, Long ownerId);
+}

--- a/backend/src/main/java/com/vaultweb/passwordmanager/backend/security/AuthenticatedUser.java
+++ b/backend/src/main/java/com/vaultweb/passwordmanager/backend/security/AuthenticatedUser.java
@@ -1,0 +1,4 @@
+package com.vaultweb.passwordmanager.backend.security;
+
+/** Lightweight principal representation for authenticated Vault Web users. */
+public record AuthenticatedUser(Long userId, String username) {}

--- a/backend/src/main/java/com/vaultweb/passwordmanager/backend/services/CategoryService.java
+++ b/backend/src/main/java/com/vaultweb/passwordmanager/backend/services/CategoryService.java
@@ -1,0 +1,52 @@
+package com.vaultweb.passwordmanager.backend.services;
+
+import com.vaultweb.passwordmanager.backend.exceptions.NotFoundException;
+import com.vaultweb.passwordmanager.backend.model.Category;
+import com.vaultweb.passwordmanager.backend.model.dtos.CategoryDto;
+import com.vaultweb.passwordmanager.backend.repositories.CategoryRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+  private final CategoryRepository repository;
+
+  public CategoryDto create(CategoryDto dto, Long ownerId) {
+    Category category = new Category();
+    category.setName(dto.getName());
+    category.setColor(dto.getColor());
+    category.setDescription(dto.getDescription());
+    category.setOwnerId(ownerId);
+    return new CategoryDto(repository.save(category));
+  }
+
+  public List<CategoryDto> getAll(Long ownerId) {
+    return repository.findAllByOwnerId(ownerId).stream().map(CategoryDto::new).toList();
+  }
+
+  public CategoryDto get(Long id, Long ownerId) {
+    return new CategoryDto(findOwned(id, ownerId));
+  }
+
+  public CategoryDto update(Long id, Long ownerId, CategoryDto dto) {
+    Category category = findOwned(id, ownerId);
+    category.setName(dto.getName());
+    category.setColor(dto.getColor());
+    category.setDescription(dto.getDescription());
+    return new CategoryDto(repository.save(category));
+  }
+
+  public void delete(Long id, Long ownerId) {
+    Category category = findOwned(id, ownerId);
+    repository.delete(category);
+  }
+
+  public Category findOwned(Long id, Long ownerId) {
+    return repository
+        .findByIdAndOwnerId(id, ownerId)
+        .orElseThrow(() -> new NotFoundException("Category not found with id " + id));
+  }
+}


### PR DESCRIPTION
### **Summary**

- Introduced tenant awareness: each password entry now stores ownderId, repositories filter by owner, and controllers/services inject the authenticated user.
- Added full category support (entity, DTO, repository, service, controller) so users can organize entries; password DTOs carry categoryId.
- Hardened security: JWT filter now injects an Authenticateduser allows Swagger assets/CORS preflight, and derives a fallback owner ID when userId isn’t in the token.
- Updated README to mention user-scoped storage.