### PR TITLE
fix: exclude master/entry passwords from DTO toString() to prevent log leaks

### DIFF
--- a/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/dtos/PasswordEntryDto.java
+++ b/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/dtos/PasswordEntryDto.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Data
 @AllArgsConstructor
@@ -24,10 +25,12 @@ public class PasswordEntryDto {
 
   @NotBlank(message = "Password is required")
   @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+  @ToString.Exclude
   private String password;
 
   @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
   @Size(min = 8, max = 1024)
+  @ToString.Exclude
   private String masterPassword;
 
   private String url;

--- a/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/dtos/PasswordGenerationResponseDto.java
+++ b/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/dtos/PasswordGenerationResponseDto.java
@@ -3,6 +3,7 @@ package com.vaultweb.passwordmanager.backend.model.dtos;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.ToString;
 
 /**
  * @author rashmi.soni
@@ -11,5 +12,6 @@ import lombok.Data;
 @AllArgsConstructor
 public class PasswordGenerationResponseDto {
   @Schema(description = "Generated strong password", example = "Aa1@bC3$dE")
+  @ToString.Exclude
   private String password;
 }

--- a/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/dtos/PasswordRevealRequestDto.java
+++ b/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/dtos/PasswordRevealRequestDto.java
@@ -2,10 +2,12 @@ package com.vaultweb.passwordmanager.backend.model.dtos;
 
 import jakarta.validation.constraints.Size;
 import lombok.Data;
+import lombok.ToString;
 
 @Data
 public class PasswordRevealRequestDto {
 
   @Size(min = 8, max = 1024)
+  @ToString.Exclude
   private String masterPassword;
 }

--- a/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/dtos/PasswordRevealResponseDto.java
+++ b/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/dtos/PasswordRevealResponseDto.java
@@ -4,6 +4,7 @@ import com.vaultweb.passwordmanager.backend.model.PasswordEntry;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.ToString;
 
 @Data
 @AllArgsConstructor
@@ -16,6 +17,7 @@ public class PasswordRevealResponseDto {
   private String name;
 
   @Schema(description = "Revealed plaintext password")
+  @ToString.Exclude
   private String password;
 
   public static PasswordRevealResponseDto fromEntry(PasswordEntry entry) {

--- a/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/dtos/VaultMigrateRequestDto.java
+++ b/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/dtos/VaultMigrateRequestDto.java
@@ -2,10 +2,12 @@ package com.vaultweb.passwordmanager.backend.model.dtos;
 
 import jakarta.validation.constraints.Size;
 import lombok.Data;
+import lombok.ToString;
 
 @Data
 public class VaultMigrateRequestDto {
 
   @Size(min = 8, max = 1024)
+  @ToString.Exclude
   private String masterPassword;
 }

--- a/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/dtos/VaultRotateRequestDto.java
+++ b/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/dtos/VaultRotateRequestDto.java
@@ -3,15 +3,18 @@ package com.vaultweb.passwordmanager.backend.model.dtos;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
+import lombok.ToString;
 
 @Data
 public class VaultRotateRequestDto {
 
   @NotBlank(message = "Current master password is required")
   @Size(min = 8, max = 1024)
+  @ToString.Exclude
   private String currentMasterPassword;
 
   @NotBlank(message = "New master password is required")
   @Size(min = 8, max = 1024)
+  @ToString.Exclude
   private String newMasterPassword;
 }

--- a/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/dtos/VaultSetupRequestDto.java
+++ b/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/dtos/VaultSetupRequestDto.java
@@ -3,11 +3,13 @@ package com.vaultweb.passwordmanager.backend.model.dtos;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
+import lombok.ToString;
 
 @Data
 public class VaultSetupRequestDto {
 
   @NotBlank(message = "Master password is required")
   @Size(min = 8, max = 1024)
+  @ToString.Exclude
   private String masterPassword;
 }

--- a/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/dtos/VaultUnlockResponseDto.java
+++ b/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/dtos/VaultUnlockResponseDto.java
@@ -3,10 +3,11 @@ package com.vaultweb.passwordmanager.backend.model.dtos;
 import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.ToString;
 
 @Data
 @AllArgsConstructor
 public class VaultUnlockResponseDto {
-  private String token;
+  @ToString.Exclude private String token;
   private Instant expiresAt;
 }

--- a/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/dtos/VaultVerifyRequestDto.java
+++ b/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/dtos/VaultVerifyRequestDto.java
@@ -3,11 +3,13 @@ package com.vaultweb.passwordmanager.backend.model.dtos;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
+import lombok.ToString;
 
 @Data
 public class VaultVerifyRequestDto {
 
   @NotBlank(message = "Master password is required")
   @Size(min = 8, max = 1024)
+  @ToString.Exclude
   private String masterPassword;
 }

--- a/backend/src/test/java/com/vaultweb/passwordmanager/backend/model/dtos/DtoToStringSecrecyTest.java
+++ b/backend/src/test/java/com/vaultweb/passwordmanager/backend/model/dtos/DtoToStringSecrecyTest.java
@@ -1,0 +1,54 @@
+package com.vaultweb.passwordmanager.backend.model.dtos;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+
+class DtoToStringSecrecyTest {
+
+  private static final String SECRET = "TOP_SECRET_VALUE";
+  private static final String OTHER_SECRET = "ANOTHER_TOP_SECRET";
+
+  @Test
+  void vaultSetupRequestDto_toStringDoesNotLeakMasterPassword() {
+    VaultSetupRequestDto dto = new VaultSetupRequestDto();
+    dto.setMasterPassword(SECRET);
+    assertFalse(dto.toString().contains(SECRET));
+  }
+
+  @Test
+  void vaultVerifyRequestDto_toStringDoesNotLeakMasterPassword() {
+    VaultVerifyRequestDto dto = new VaultVerifyRequestDto();
+    dto.setMasterPassword(SECRET);
+    assertFalse(dto.toString().contains(SECRET));
+  }
+
+  @Test
+  void passwordRevealRequestDto_toStringDoesNotLeakMasterPassword() {
+    PasswordRevealRequestDto dto = new PasswordRevealRequestDto();
+    dto.setMasterPassword(SECRET);
+    assertFalse(dto.toString().contains(SECRET));
+  }
+
+  @Test
+  void vaultRotateRequestDto_toStringDoesNotLeakMasterPasswords() {
+    VaultRotateRequestDto dto = new VaultRotateRequestDto();
+    dto.setCurrentMasterPassword(SECRET);
+    dto.setNewMasterPassword(OTHER_SECRET);
+    String result = dto.toString();
+    assertFalse(result.contains(SECRET));
+    assertFalse(result.contains(OTHER_SECRET));
+  }
+
+  @Test
+  void passwordEntryDto_toStringDoesNotLeakPasswordOrMasterPassword() {
+    PasswordEntryDto dto = new PasswordEntryDto();
+    dto.setName("GitHub");
+    dto.setUsername("gabriel");
+    dto.setPassword(SECRET);
+    dto.setMasterPassword(OTHER_SECRET);
+    String result = dto.toString();
+    assertFalse(result.contains(SECRET));
+    assertFalse(result.contains(OTHER_SECRET));
+  }
+}

--- a/backend/src/test/java/com/vaultweb/passwordmanager/backend/model/dtos/DtoToStringSecrecyTest.java
+++ b/backend/src/test/java/com/vaultweb/passwordmanager/backend/model/dtos/DtoToStringSecrecyTest.java
@@ -2,6 +2,7 @@ package com.vaultweb.passwordmanager.backend.model.dtos;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
+import java.time.Instant;
 import org.junit.jupiter.api.Test;
 
 class DtoToStringSecrecyTest {
@@ -50,5 +51,30 @@ class DtoToStringSecrecyTest {
     String result = dto.toString();
     assertFalse(result.contains(SECRET));
     assertFalse(result.contains(OTHER_SECRET));
+  }
+
+  @Test
+  void vaultMigrateRequestDto_toStringDoesNotLeakMasterPassword() {
+    VaultMigrateRequestDto dto = new VaultMigrateRequestDto();
+    dto.setMasterPassword(SECRET);
+    assertFalse(dto.toString().contains(SECRET));
+  }
+
+  @Test
+  void passwordGenerationResponseDto_toStringDoesNotLeakPassword() {
+    PasswordGenerationResponseDto dto = new PasswordGenerationResponseDto(SECRET);
+    assertFalse(dto.toString().contains(SECRET));
+  }
+
+  @Test
+  void passwordRevealResponseDto_toStringDoesNotLeakPassword() {
+    PasswordRevealResponseDto dto = new PasswordRevealResponseDto(1L, "GitHub", SECRET);
+    assertFalse(dto.toString().contains(SECRET));
+  }
+
+  @Test
+  void vaultUnlockResponseDto_toStringDoesNotLeakToken() {
+    VaultUnlockResponseDto dto = new VaultUnlockResponseDto(SECRET, Instant.ofEpochMilli(0));
+    assertFalse(dto.toString().contains(SECRET));
   }
 }


### PR DESCRIPTION
## What

The DTOs carrying the master password (and the stored entry password) use Lombok `@Data`, whose generated `toString()` includes every field — so logging any of them (a debug log, an exception that interpolates the request body, etc.) writes the plaintext master password to the logs. `@JsonProperty(WRITE_ONLY)` covers JSON responses, but `toString()` is a separate path.

Affected: `VaultSetupRequestDto`, `VaultVerifyRequestDto`, `PasswordRevealRequestDto` (`masterPassword`); `VaultRotateRequestDto` (`currentMasterPassword`, `newMasterPassword`); `PasswordEntryDto` (`password`, `masterPassword`).

## Fix

Add `@ToString.Exclude` to those fields. Getters/setters, JSON binding and validation are unchanged.

## Test

`DtoToStringSecrecyTest` asserts `toString()` of each DTO does not contain the secret values — it fails on the current code (the secrets are present) and passes with the fix. All existing tests still pass.

Fixes #86
