### PR TITLE
feat: encrypted vault export & import (CSV)

### DIFF
--- a/backend/src/main/java/com/vaultweb/passwordmanager/backend/controllers/VaultPortabilityController.java
+++ b/backend/src/main/java/com/vaultweb/passwordmanager/backend/controllers/VaultPortabilityController.java
@@ -1,0 +1,71 @@
+package com.vaultweb.passwordmanager.backend.controllers;
+
+import com.vaultweb.passwordmanager.backend.model.dtos.VaultExportRequestDto;
+import com.vaultweb.passwordmanager.backend.model.dtos.VaultImportRequestDto;
+import com.vaultweb.passwordmanager.backend.model.dtos.VaultImportResponseDto;
+import com.vaultweb.passwordmanager.backend.security.AuthenticatedUser;
+import com.vaultweb.passwordmanager.backend.services.VaultPortabilityService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Export and import the vault (issue #81). */
+@RestController
+@RequestMapping("/api/vault")
+@RequiredArgsConstructor
+public class VaultPortabilityController {
+
+  private static final MediaType TEXT_CSV = new MediaType("text", "csv");
+
+  private final VaultPortabilityService portabilityService;
+
+  /**
+   * Exports the authenticated user's vault. The response is a downloadable file: an encrypted
+   * envelope by default, or a plaintext CSV when explicitly confirmed.
+   */
+  @PostMapping("/export")
+  public ResponseEntity<String> export(
+      @AuthenticationPrincipal AuthenticatedUser user,
+      @RequestHeader(value = "X-Vault-Token", required = false) String vaultToken,
+      @Valid @RequestBody VaultExportRequestDto dto) {
+    boolean encrypted = dto.getEncrypted() == null || dto.getEncrypted();
+    VaultPortabilityService.VaultExportResult result =
+        portabilityService.export(
+            user.userId(),
+            dto.getMasterPassword(),
+            vaultToken,
+            encrypted,
+            dto.getExportPassword(),
+            Boolean.TRUE.equals(dto.getConfirmPlaintext()));
+
+    String filename = result.encrypted() ? "vault-export.vault" : "vault-export.csv";
+    MediaType contentType = result.encrypted() ? MediaType.APPLICATION_OCTET_STREAM : TEXT_CSV;
+    return ResponseEntity.ok()
+        .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"")
+        .contentType(contentType)
+        .body(result.content());
+  }
+
+  /** Imports entries into the authenticated user's vault from an export file or plaintext CSV. */
+  @PostMapping("/import")
+  public ResponseEntity<VaultImportResponseDto> importVault(
+      @AuthenticationPrincipal AuthenticatedUser user,
+      @RequestHeader(value = "X-Vault-Token", required = false) String vaultToken,
+      @Valid @RequestBody VaultImportRequestDto dto) {
+    return ResponseEntity.ok(
+        portabilityService.importVault(
+            user.userId(),
+            dto.getData(),
+            dto.getImportPassword(),
+            dto.getMasterPassword(),
+            vaultToken));
+  }
+}

--- a/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/dtos/VaultExportRequestDto.java
+++ b/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/dtos/VaultExportRequestDto.java
@@ -1,0 +1,30 @@
+package com.vaultweb.passwordmanager.backend.model.dtos;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.ToString;
+
+/**
+ * Request body for exporting the vault.
+ *
+ * <p>Either {@code masterPassword} or the {@code X-Vault-Token} header is used to unlock the vault.
+ * When {@code encrypted} is {@code true} (the default), {@code exportPassword} protects the export
+ * file. A plaintext export must be explicitly confirmed via {@code confirmPlaintext}.
+ */
+@Data
+public class VaultExportRequestDto {
+
+  @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+  @ToString.Exclude
+  private String masterPassword;
+
+  @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+  @ToString.Exclude
+  private String exportPassword;
+
+  /** Whether the export is encrypted. Defaults to {@code true} when omitted. */
+  private Boolean encrypted;
+
+  /** Explicit acknowledgement required to produce an unencrypted (plaintext) export. */
+  private Boolean confirmPlaintext;
+}

--- a/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/dtos/VaultImportRequestDto.java
+++ b/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/dtos/VaultImportRequestDto.java
@@ -1,0 +1,31 @@
+package com.vaultweb.passwordmanager.backend.model.dtos;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+import lombok.ToString;
+
+/**
+ * Request body for importing into the vault.
+ *
+ * <p>{@code data} is either an encrypted vault export or a plaintext CSV; the format is
+ * auto-detected. {@code importPassword} is required only when {@code data} is an encrypted export.
+ * Either {@code masterPassword} or the {@code X-Vault-Token} header unlocks the vault so imported
+ * passwords can be encrypted at rest.
+ */
+@Data
+public class VaultImportRequestDto {
+
+  @NotBlank(message = "Import data is required")
+  @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+  @ToString.Exclude
+  private String data;
+
+  @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+  @ToString.Exclude
+  private String importPassword;
+
+  @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+  @ToString.Exclude
+  private String masterPassword;
+}

--- a/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/dtos/VaultImportResponseDto.java
+++ b/backend/src/main/java/com/vaultweb/passwordmanager/backend/model/dtos/VaultImportResponseDto.java
@@ -1,0 +1,18 @@
+package com.vaultweb.passwordmanager.backend.model.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Summary of a vault import: how many entries were created, categories created, and rows skipped.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class VaultImportResponseDto {
+
+  private int imported;
+  private int categoriesCreated;
+  private int skipped;
+}

--- a/backend/src/main/java/com/vaultweb/passwordmanager/backend/services/VaultCryptoService.java
+++ b/backend/src/main/java/com/vaultweb/passwordmanager/backend/services/VaultCryptoService.java
@@ -1,11 +1,13 @@
 package com.vaultweb.passwordmanager.backend.services;
 
+import com.vaultweb.passwordmanager.backend.exceptions.InvalidCredentialsException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.util.Base64;
+import javax.crypto.AEADBadTagException;
 import javax.crypto.Cipher;
 import javax.crypto.Mac;
 import javax.crypto.SecretKeyFactory;
@@ -20,10 +22,16 @@ public class VaultCryptoService {
 
   public static final String PASSWORD_PREFIX = "v1:";
 
+  /** Magic prefix identifying a password-encrypted vault export envelope. */
+  public static final String EXPORT_PREFIX = "VWENC1:";
+
   private static final int PBKDF2_SALT_LEN = 16;
   private static final int PBKDF2_KEY_LEN_BYTES = 32;
 
   private static final int DEFAULT_PBKDF2_ITERATIONS = 210_000;
+
+  /** Defensive upper bound on the PBKDF2 iterations read from an untrusted export envelope. */
+  private static final int MAX_EXPORT_ITERATIONS = 10_000_000;
 
   private static final int GCM_IV_LENGTH = 12;
   private static final int GCM_TAG_LENGTH = 128;
@@ -177,6 +185,104 @@ public class VaultCryptoService {
     String blob = encrypted.substring(PASSWORD_PREFIX.length());
     byte[] plainBytes = decryptAesGcmFromBase64(dekBytes, blob, aadForOwner(ownerId));
     return new String(plainBytes, StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Checks whether the given value is a password-encrypted vault export envelope.
+   *
+   * @param value the value to inspect
+   * @return true if the value carries the export envelope prefix
+   */
+  public boolean isEncryptedExport(String value) {
+    return value != null && value.startsWith(EXPORT_PREFIX);
+  }
+
+  /**
+   * Encrypts arbitrary bytes under a password into a self-contained, portable envelope.
+   *
+   * <p>The envelope is {@code EXPORT_PREFIX + base64(iterations | salt | iv | ciphertext+tag)} and
+   * is deliberately not bound to an owner (no AAD) so an export can be restored on any vault
+   * instance using only the export password.
+   *
+   * @param plaintext the bytes to encrypt
+   * @param password the export password
+   * @return the encrypted envelope string
+   */
+  public String encryptWithPassword(byte[] plaintext, String password) {
+    byte[] salt = randomSalt();
+    int iterations = defaultPbkdf2Iterations;
+    byte[] key = deriveKek(password, salt, iterations);
+    try {
+      byte[] iv = new byte[GCM_IV_LENGTH];
+      secureRandom.nextBytes(iv);
+
+      Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+      cipher.init(
+          Cipher.ENCRYPT_MODE,
+          new SecretKeySpec(key, "AES"),
+          new GCMParameterSpec(GCM_TAG_LENGTH, iv));
+      byte[] ciphertext = cipher.doFinal(plaintext);
+
+      ByteBuffer buffer =
+          ByteBuffer.allocate(Integer.BYTES + salt.length + iv.length + ciphertext.length);
+      buffer.putInt(iterations);
+      buffer.put(salt);
+      buffer.put(iv);
+      buffer.put(ciphertext);
+      return EXPORT_PREFIX + Base64.getEncoder().encodeToString(buffer.array());
+    } catch (GeneralSecurityException e) {
+      throw new IllegalStateException("Export encryption failed", e);
+    }
+  }
+
+  /**
+   * Decrypts an envelope produced by {@link #encryptWithPassword(byte[], String)}.
+   *
+   * @param encrypted the encrypted envelope string
+   * @param password the export password
+   * @return the decrypted plaintext bytes
+   * @throws InvalidCredentialsException if the password is wrong or the data was tampered with
+   * @throws IllegalArgumentException if the envelope is not well-formed
+   */
+  public byte[] decryptWithPassword(String encrypted, String password) {
+    if (!isEncryptedExport(encrypted)) {
+      throw new IllegalArgumentException("Not an encrypted vault export");
+    }
+    byte[] decoded;
+    try {
+      decoded = Base64.getDecoder().decode(encrypted.substring(EXPORT_PREFIX.length()));
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Malformed vault export", e);
+    }
+    if (decoded.length < Integer.BYTES + PBKDF2_SALT_LEN + GCM_IV_LENGTH + (GCM_TAG_LENGTH / 8)) {
+      throw new IllegalArgumentException("Malformed vault export: too short");
+    }
+
+    ByteBuffer buffer = ByteBuffer.wrap(decoded);
+    int iterations = buffer.getInt();
+    if (iterations <= 0 || iterations > MAX_EXPORT_ITERATIONS) {
+      throw new IllegalArgumentException("Malformed vault export: invalid iteration count");
+    }
+    byte[] salt = new byte[PBKDF2_SALT_LEN];
+    buffer.get(salt);
+    byte[] iv = new byte[GCM_IV_LENGTH];
+    buffer.get(iv);
+    byte[] ciphertext = new byte[buffer.remaining()];
+    buffer.get(ciphertext);
+
+    byte[] key = deriveKek(password, salt, iterations);
+    try {
+      Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+      cipher.init(
+          Cipher.DECRYPT_MODE,
+          new SecretKeySpec(key, "AES"),
+          new GCMParameterSpec(GCM_TAG_LENGTH, iv));
+      return cipher.doFinal(ciphertext);
+    } catch (AEADBadTagException e) {
+      throw new InvalidCredentialsException("Invalid export password or corrupted export file");
+    } catch (GeneralSecurityException e) {
+      throw new IllegalStateException("Export decryption failed", e);
+    }
   }
 
   /**

--- a/backend/src/main/java/com/vaultweb/passwordmanager/backend/services/VaultPortabilityService.java
+++ b/backend/src/main/java/com/vaultweb/passwordmanager/backend/services/VaultPortabilityService.java
@@ -1,0 +1,278 @@
+package com.vaultweb.passwordmanager.backend.services;
+
+import com.vaultweb.passwordmanager.backend.exceptions.VaultLockedException;
+import com.vaultweb.passwordmanager.backend.model.Category;
+import com.vaultweb.passwordmanager.backend.model.PasswordEntry;
+import com.vaultweb.passwordmanager.backend.model.dtos.VaultImportResponseDto;
+import com.vaultweb.passwordmanager.backend.repositories.CategoryRepository;
+import com.vaultweb.passwordmanager.backend.repositories.PasswordEntryRepository;
+import com.vaultweb.passwordmanager.backend.support.CsvSupport;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Exports and imports the vault as CSV, addressing the lock-in concern in issue #81.
+ *
+ * <p>Export is encrypted by default (password-protected envelope); a plaintext CSV requires
+ * explicit confirmation. Import auto-detects an encrypted envelope vs. a plaintext CSV, maps common
+ * column headers from other managers (Bitwarden, KeePass) so entries can be brought in without
+ * manual editing, and recreates categories by name. Passwords are always stored using the same
+ * vault encryption path as normal entry creation.
+ */
+@Service
+@RequiredArgsConstructor
+public class VaultPortabilityService {
+
+  private static final String[] CSV_HEADER = {
+    "name", "username", "password", "url", "notes", "category"
+  };
+
+  private static final Map<String, String> COLUMN_ALIASES = buildColumnAliases();
+
+  private static final char BYTE_ORDER_MARK = (char) 0xFEFF;
+
+  private final PasswordEntryRepository passwordEntryRepository;
+  private final CategoryRepository categoryRepository;
+  private final VaultService vaultService;
+  private final VaultSessionService vaultSessionService;
+  private final VaultCryptoService crypto;
+
+  /** Result of an export: the file content, whether it is encrypted, and the entry count. */
+  public record VaultExportResult(String content, boolean encrypted, int entryCount) {}
+
+  /**
+   * Exports all of the owner's entries as CSV, optionally encrypted under an export password.
+   *
+   * @param ownerId the vault owner
+   * @param masterPassword master password (used when no vault token is supplied)
+   * @param vaultToken active vault session token, or null
+   * @param encrypted whether to encrypt the export (the default)
+   * @param exportPassword password protecting an encrypted export
+   * @param confirmPlaintext explicit acknowledgement required for an unencrypted export
+   * @return the export result
+   */
+  @Transactional(readOnly = true)
+  public VaultExportResult export(
+      Long ownerId,
+      String masterPassword,
+      String vaultToken,
+      boolean encrypted,
+      String exportPassword,
+      boolean confirmPlaintext) {
+    if (encrypted) {
+      if (isBlank(exportPassword)) {
+        throw new IllegalArgumentException("exportPassword is required for an encrypted export");
+      }
+    } else if (!confirmPlaintext) {
+      throw new IllegalArgumentException(
+          "Plaintext export must be explicitly confirmed (confirmPlaintext=true)");
+    }
+
+    byte[] dek = resolveDek(ownerId, masterPassword, vaultToken);
+    List<PasswordEntry> entries = passwordEntryRepository.findAllByOwnerId(ownerId);
+
+    List<String[]> rows = new ArrayList<>();
+    rows.add(CSV_HEADER.clone());
+    for (PasswordEntry entry : entries) {
+      String category = entry.getCategory() != null ? entry.getCategory().getName() : "";
+      rows.add(
+          new String[] {
+            nullToEmpty(entry.getName()),
+            nullToEmpty(entry.getUsername()),
+            decryptForExport(ownerId, dek, entry),
+            nullToEmpty(entry.getUrl()),
+            nullToEmpty(entry.getNotes()),
+            nullToEmpty(category)
+          });
+    }
+    String csv = CsvSupport.write(rows);
+
+    if (encrypted) {
+      String envelope =
+          crypto.encryptWithPassword(csv.getBytes(StandardCharsets.UTF_8), exportPassword);
+      return new VaultExportResult(envelope, true, entries.size());
+    }
+    return new VaultExportResult(csv, false, entries.size());
+  }
+
+  /**
+   * Imports entries from an encrypted export envelope or a plaintext CSV (format auto-detected).
+   *
+   * @param ownerId the vault owner
+   * @param data the encrypted envelope or plaintext CSV
+   * @param importPassword export password (required only for an encrypted envelope)
+   * @param masterPassword master password (used when no vault token is supplied)
+   * @param vaultToken active vault session token, or null
+   * @return a summary of what was imported
+   */
+  @Transactional
+  public VaultImportResponseDto importVault(
+      Long ownerId, String data, String importPassword, String masterPassword, String vaultToken) {
+    if (isBlank(data)) {
+      throw new IllegalArgumentException("No data to import");
+    }
+
+    String csv;
+    String candidate = data.stripLeading();
+    if (crypto.isEncryptedExport(candidate)) {
+      if (isBlank(importPassword)) {
+        throw new IllegalArgumentException("importPassword is required for an encrypted export");
+      }
+      csv =
+          new String(crypto.decryptWithPassword(candidate, importPassword), StandardCharsets.UTF_8);
+    } else {
+      csv = data;
+    }
+    csv = stripByteOrderMark(csv);
+
+    List<String[]> rows = CsvSupport.parse(csv);
+    if (rows.isEmpty()) {
+      return new VaultImportResponseDto(0, 0, 0);
+    }
+
+    Map<String, Integer> columns = mapHeader(rows.get(0));
+    if (!columns.containsKey("name") || !columns.containsKey("password")) {
+      throw new IllegalArgumentException(
+          "Unrecognized CSV header; expected columns such as name, username, password, url, notes, category");
+    }
+
+    byte[] dek = resolveDek(ownerId, masterPassword, vaultToken);
+    Map<String, Category> categoriesByName = new HashMap<>();
+    for (Category category : categoryRepository.findAllByOwnerId(ownerId)) {
+      categoriesByName.put(category.getName().toLowerCase(Locale.ROOT), category);
+    }
+
+    int imported = 0;
+    int categoriesCreated = 0;
+    int skipped = 0;
+    for (int r = 1; r < rows.size(); r++) {
+      String[] row = rows.get(r);
+      String name = field(row, columns, "name");
+      String username = field(row, columns, "username");
+      String password = field(row, columns, "password");
+
+      // The entry model requires name, username, and password; skip rows that cannot form one.
+      if (isBlank(name) || isBlank(username) || isBlank(password)) {
+        skipped++;
+        continue;
+      }
+
+      PasswordEntry entry = new PasswordEntry();
+      entry.setOwnerId(ownerId);
+      entry.setName(name);
+      entry.setUsername(username);
+      entry.setUrl(emptyToNull(field(row, columns, "url")));
+      entry.setNotes(emptyToNull(field(row, columns, "notes")));
+
+      String categoryName = field(row, columns, "category");
+      if (!isBlank(categoryName)) {
+        String key = categoryName.toLowerCase(Locale.ROOT);
+        Category category = categoriesByName.get(key);
+        if (category == null) {
+          category = new Category();
+          category.setName(categoryName.trim());
+          category.setOwnerId(ownerId);
+          category = categoryRepository.save(category);
+          categoriesByName.put(key, category);
+          categoriesCreated++;
+        }
+        entry.setCategory(category);
+      }
+
+      entry.setPassword(encryptForStorage(ownerId, dek, password));
+      passwordEntryRepository.save(entry);
+      imported++;
+    }
+    return new VaultImportResponseDto(imported, categoriesCreated, skipped);
+  }
+
+  /** Resolves the DEK once: null when the vault is not initialized (passwords are plaintext). */
+  private byte[] resolveDek(Long ownerId, String masterPassword, String vaultToken) {
+    if (!vaultService.isInitialized(ownerId)) {
+      return null;
+    }
+    if (!isBlank(vaultToken)) {
+      return vaultSessionService.requireDek(ownerId, vaultToken);
+    }
+    if (isBlank(masterPassword)) {
+      throw new VaultLockedException("Master password or vault token required (vault initialized)");
+    }
+    return vaultService.unwrapDekForSession(ownerId, masterPassword);
+  }
+
+  /** Decrypts a stored password for export without triggering the reveal-path migration write. */
+  private String decryptForExport(Long ownerId, byte[] dek, PasswordEntry entry) {
+    String stored = entry.getPassword();
+    if (dek == null || !crypto.isVaultEncryptedPassword(stored)) {
+      return nullToEmpty(stored);
+    }
+    return crypto.decryptPasswordWithDek(dek, stored, ownerId);
+  }
+
+  private String encryptForStorage(Long ownerId, byte[] dek, String password) {
+    if (dek == null) {
+      return vaultService.encryptPasswordForStorage(ownerId, null, password);
+    }
+    return vaultService.encryptPasswordForStorageWithDek(ownerId, dek, password);
+  }
+
+  private static Map<String, Integer> mapHeader(String[] header) {
+    Map<String, Integer> columns = new HashMap<>();
+    for (int i = 0; i < header.length; i++) {
+      String key = header[i] == null ? "" : header[i].trim().toLowerCase(Locale.ROOT);
+      String canonical = COLUMN_ALIASES.get(key);
+      if (canonical != null) {
+        columns.putIfAbsent(canonical, i);
+      }
+    }
+    return columns;
+  }
+
+  private static String field(String[] row, Map<String, Integer> columns, String canonical) {
+    Integer index = columns.get(canonical);
+    if (index == null || index >= row.length || row[index] == null) {
+      return "";
+    }
+    return row[index];
+  }
+
+  private static Map<String, String> buildColumnAliases() {
+    Map<String, String> aliases = new HashMap<>();
+    putAll(aliases, "name", "name", "title", "service");
+    putAll(aliases, "username", "username", "user", "login", "login_username", "login name");
+    putAll(aliases, "password", "password", "login_password");
+    putAll(aliases, "url", "url", "uri", "website", "login_uri");
+    putAll(aliases, "notes", "notes", "note");
+    putAll(aliases, "category", "category", "folder", "group", "grouping");
+    return aliases;
+  }
+
+  private static void putAll(Map<String, String> map, String canonical, String... names) {
+    for (String name : names) {
+      map.put(name, canonical);
+    }
+  }
+
+  private static boolean isBlank(String value) {
+    return value == null || value.isBlank();
+  }
+
+  private static String nullToEmpty(String value) {
+    return value == null ? "" : value;
+  }
+
+  private static String emptyToNull(String value) {
+    return isBlank(value) ? null : value;
+  }
+
+  private static String stripByteOrderMark(String value) {
+    return !value.isEmpty() && value.charAt(0) == BYTE_ORDER_MARK ? value.substring(1) : value;
+  }
+}

--- a/backend/src/main/java/com/vaultweb/passwordmanager/backend/support/CsvSupport.java
+++ b/backend/src/main/java/com/vaultweb/passwordmanager/backend/support/CsvSupport.java
@@ -1,0 +1,118 @@
+package com.vaultweb.passwordmanager.backend.support;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Minimal RFC 4180 CSV writer and parser.
+ *
+ * <p>Kept dependency-free on purpose: the vault export/import only needs a small, predictable CSV
+ * implementation, and pulling in a CSV library for that would be overkill. Fields are quoted only
+ * when they contain a comma, double quote, or line break; embedded double quotes are escaped by
+ * doubling them. Rows are separated by CRLF on write, and parsing accepts both CRLF and LF.
+ */
+public final class CsvSupport {
+
+  private static final char DELIMITER = ',';
+  private static final char QUOTE = '"';
+  private static final String ROW_SEPARATOR = "\r\n";
+
+  private CsvSupport() {}
+
+  /**
+   * Serializes the given rows to a CSV string.
+   *
+   * @param rows the rows to write; each element is one record's fields
+   * @return the CSV representation, with CRLF row separators
+   */
+  public static String write(List<String[]> rows) {
+    StringBuilder sb = new StringBuilder();
+    for (String[] row : rows) {
+      for (int i = 0; i < row.length; i++) {
+        if (i > 0) {
+          sb.append(DELIMITER);
+        }
+        sb.append(escape(row[i]));
+      }
+      sb.append(ROW_SEPARATOR);
+    }
+    return sb.toString();
+  }
+
+  private static String escape(String field) {
+    String value = field == null ? "" : field;
+    boolean mustQuote =
+        value.indexOf(DELIMITER) >= 0
+            || value.indexOf(QUOTE) >= 0
+            || value.indexOf('\n') >= 0
+            || value.indexOf('\r') >= 0;
+    if (!mustQuote) {
+      return value;
+    }
+    return QUOTE + value.replace("\"", "\"\"") + QUOTE;
+  }
+
+  /**
+   * Parses a CSV string into rows. Handles quoted fields containing commas, quotes, and line
+   * breaks. Both CRLF and LF line endings are accepted.
+   *
+   * @param csv the CSV text to parse
+   * @return the parsed rows; each element is one record's fields
+   */
+  public static List<String[]> parse(String csv) {
+    List<String[]> rows = new ArrayList<>();
+    List<String> current = new ArrayList<>();
+    StringBuilder field = new StringBuilder();
+    boolean inQuotes = false;
+    boolean rowHasContent = false;
+    int i = 0;
+    int n = csv.length();
+
+    while (i < n) {
+      char c = csv.charAt(i);
+      if (inQuotes) {
+        if (c == QUOTE) {
+          if (i + 1 < n && csv.charAt(i + 1) == QUOTE) {
+            field.append(QUOTE);
+            i += 2;
+          } else {
+            inQuotes = false;
+            i++;
+          }
+        } else {
+          field.append(c);
+          i++;
+        }
+        continue;
+      }
+
+      if (c == QUOTE) {
+        inQuotes = true;
+        rowHasContent = true;
+        i++;
+      } else if (c == DELIMITER) {
+        current.add(field.toString());
+        field.setLength(0);
+        rowHasContent = true;
+        i++;
+      } else if (c == '\r' || c == '\n') {
+        current.add(field.toString());
+        field.setLength(0);
+        rows.add(current.toArray(new String[0]));
+        current = new ArrayList<>();
+        rowHasContent = false;
+        i += (c == '\r' && i + 1 < n && csv.charAt(i + 1) == '\n') ? 2 : 1;
+      } else {
+        field.append(c);
+        rowHasContent = true;
+        i++;
+      }
+    }
+
+    if (rowHasContent || field.length() > 0 || !current.isEmpty()) {
+      current.add(field.toString());
+      rows.add(current.toArray(new String[0]));
+    }
+    return rows;
+  }
+}

--- a/backend/src/test/java/com/vaultweb/passwordmanager/backend/model/dtos/DtoToStringSecrecyTest.java
+++ b/backend/src/test/java/com/vaultweb/passwordmanager/backend/model/dtos/DtoToStringSecrecyTest.java
@@ -77,4 +77,26 @@ class DtoToStringSecrecyTest {
     VaultUnlockResponseDto dto = new VaultUnlockResponseDto(SECRET, Instant.ofEpochMilli(0));
     assertFalse(dto.toString().contains(SECRET));
   }
+
+  @Test
+  void vaultExportRequestDto_toStringDoesNotLeakSecrets() {
+    VaultExportRequestDto dto = new VaultExportRequestDto();
+    dto.setMasterPassword(SECRET);
+    dto.setExportPassword(OTHER_SECRET);
+    String result = dto.toString();
+    assertFalse(result.contains(SECRET));
+    assertFalse(result.contains(OTHER_SECRET));
+  }
+
+  @Test
+  void vaultImportRequestDto_toStringDoesNotLeakSecretsOrData() {
+    VaultImportRequestDto dto = new VaultImportRequestDto();
+    dto.setData(SECRET);
+    dto.setImportPassword(OTHER_SECRET);
+    dto.setMasterPassword("yet-another-top-secret");
+    String result = dto.toString();
+    assertFalse(result.contains(SECRET));
+    assertFalse(result.contains(OTHER_SECRET));
+    assertFalse(result.contains("yet-another-top-secret"));
+  }
 }

--- a/backend/src/test/java/com/vaultweb/passwordmanager/backend/services/VaultCryptoServiceExportTest.java
+++ b/backend/src/test/java/com/vaultweb/passwordmanager/backend/services/VaultCryptoServiceExportTest.java
@@ -1,0 +1,51 @@
+package com.vaultweb.passwordmanager.backend.services;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.vaultweb.passwordmanager.backend.exceptions.InvalidCredentialsException;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+class VaultCryptoServiceExportTest {
+
+  // Reduced iterations keep the test fast; the algorithm is identical to production.
+  private final VaultCryptoService crypto = new VaultCryptoService(10_000);
+
+  @Test
+  void encryptThenDecryptRoundTrips() {
+    byte[] plaintext =
+        "name,username,password\r\nGitHub,gabriel,s3cr3t\r\n".getBytes(StandardCharsets.UTF_8);
+    String envelope = crypto.encryptWithPassword(plaintext, "export-pw");
+
+    assertTrue(crypto.isEncryptedExport(envelope));
+    assertArrayEquals(plaintext, crypto.decryptWithPassword(envelope, "export-pw"));
+  }
+
+  @Test
+  void wrongPasswordIsRejected() {
+    String envelope = crypto.encryptWithPassword("data".getBytes(StandardCharsets.UTF_8), "right");
+    assertThrows(
+        InvalidCredentialsException.class, () -> crypto.decryptWithPassword(envelope, "wrong"));
+  }
+
+  @Test
+  void plaintextCsvIsNotDetectedAsEncrypted() {
+    assertFalse(crypto.isEncryptedExport("name,username,password\r\nGitHub,gabriel,pw"));
+  }
+
+  @Test
+  void decryptingNonEnvelopeThrows() {
+    assertThrows(
+        IllegalArgumentException.class, () -> crypto.decryptWithPassword("not-an-envelope", "pw"));
+  }
+
+  @Test
+  void decryptingTruncatedEnvelopeThrows() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> crypto.decryptWithPassword(VaultCryptoService.EXPORT_PREFIX + "AAAA", "pw"));
+  }
+}

--- a/backend/src/test/java/com/vaultweb/passwordmanager/backend/services/VaultPortabilityServiceTest.java
+++ b/backend/src/test/java/com/vaultweb/passwordmanager/backend/services/VaultPortabilityServiceTest.java
@@ -1,0 +1,196 @@
+package com.vaultweb.passwordmanager.backend.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.vaultweb.passwordmanager.backend.exceptions.InvalidCredentialsException;
+import com.vaultweb.passwordmanager.backend.model.Category;
+import com.vaultweb.passwordmanager.backend.model.PasswordEntry;
+import com.vaultweb.passwordmanager.backend.model.dtos.VaultImportResponseDto;
+import com.vaultweb.passwordmanager.backend.repositories.CategoryRepository;
+import com.vaultweb.passwordmanager.backend.repositories.PasswordEntryRepository;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class VaultPortabilityServiceTest {
+
+  private static final Long OWNER = 7L;
+
+  private PasswordEntryRepository passwordEntryRepository;
+  private CategoryRepository categoryRepository;
+  private VaultService vaultService;
+  private VaultSessionService vaultSessionService;
+  private VaultCryptoService crypto;
+  private VaultPortabilityService service;
+
+  @BeforeEach
+  void setUp() {
+    passwordEntryRepository = mock(PasswordEntryRepository.class);
+    categoryRepository = mock(CategoryRepository.class);
+    vaultService = mock(VaultService.class);
+    vaultSessionService = mock(VaultSessionService.class);
+    crypto = new VaultCryptoService(10_000); // real crypto for the export envelope
+
+    service =
+        new VaultPortabilityService(
+            passwordEntryRepository, categoryRepository, vaultService, vaultSessionService, crypto);
+
+    // Vault not initialized: entry passwords are plaintext, so storage encryption is passthrough.
+    when(vaultService.isInitialized(OWNER)).thenReturn(false);
+    when(vaultService.encryptPasswordForStorage(eq(OWNER), isNull(), anyString()))
+        .thenAnswer(inv -> inv.getArgument(2));
+    when(categoryRepository.findAllByOwnerId(OWNER)).thenReturn(new ArrayList<>());
+  }
+
+  private PasswordEntry entry(
+      String name, String username, String password, String url, String notes, Category category) {
+    PasswordEntry e = new PasswordEntry();
+    e.setOwnerId(OWNER);
+    e.setName(name);
+    e.setUsername(username);
+    e.setPassword(password);
+    e.setUrl(url);
+    e.setNotes(notes);
+    e.setCategory(category);
+    return e;
+  }
+
+  @Test
+  void encryptedExportThenImportRoundTrips() {
+    Category social = new Category();
+    social.setId(1L);
+    social.setName("Social");
+    social.setOwnerId(OWNER);
+    List<PasswordEntry> entries =
+        List.of(
+            entry("GitHub", "gabriel", "s3cr3t", "https://github.com", "main, account", social),
+            entry("Email", "gab@x.com", "p@ss\"word", null, "with\nnewline", null));
+    when(passwordEntryRepository.findAllByOwnerId(OWNER)).thenReturn(entries);
+
+    VaultPortabilityService.VaultExportResult result =
+        service.export(OWNER, null, null, true, "export-pw", false);
+    assertTrue(result.encrypted());
+    assertEquals(2, result.entryCount());
+    assertTrue(crypto.isEncryptedExport(result.content()));
+
+    when(categoryRepository.save(any(Category.class)))
+        .thenAnswer(
+            inv -> {
+              Category c = inv.getArgument(0);
+              c.setId(99L);
+              return c;
+            });
+    ArgumentCaptor<PasswordEntry> captor = ArgumentCaptor.forClass(PasswordEntry.class);
+    when(passwordEntryRepository.save(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+    VaultImportResponseDto summary =
+        service.importVault(OWNER, result.content(), "export-pw", null, null);
+
+    assertEquals(2, summary.getImported());
+    List<PasswordEntry> created = captor.getAllValues();
+    assertEquals(2, created.size());
+
+    PasswordEntry github =
+        created.stream().filter(e -> "GitHub".equals(e.getName())).findFirst().orElseThrow();
+    assertEquals("gabriel", github.getUsername());
+    assertEquals("s3cr3t", github.getPassword());
+    assertEquals("https://github.com", github.getUrl());
+    assertEquals("main, account", github.getNotes()); // comma survived the CSV round-trip
+    assertEquals("Social", github.getCategory().getName());
+
+    PasswordEntry email =
+        created.stream().filter(e -> "Email".equals(e.getName())).findFirst().orElseThrow();
+    assertEquals("p@ss\"word", email.getPassword()); // quote survived
+    assertEquals("with\nnewline", email.getNotes()); // embedded newline survived
+    assertNull(email.getUrl());
+  }
+
+  @Test
+  void plaintextExportRequiresConfirmation() {
+    when(passwordEntryRepository.findAllByOwnerId(OWNER)).thenReturn(List.of());
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> service.export(OWNER, null, null, false, null, false));
+
+    VaultPortabilityService.VaultExportResult confirmed =
+        service.export(OWNER, null, null, false, null, true);
+    assertFalse(confirmed.encrypted());
+    assertFalse(crypto.isEncryptedExport(confirmed.content()));
+  }
+
+  @Test
+  void encryptedExportRequiresExportPassword() {
+    assertThrows(
+        IllegalArgumentException.class, () -> service.export(OWNER, null, null, true, "  ", false));
+  }
+
+  @Test
+  void importWithWrongPasswordFails() {
+    when(passwordEntryRepository.findAllByOwnerId(OWNER))
+        .thenReturn(List.of(entry("GitHub", "gabriel", "s3cr3t", null, null, null)));
+    String blob = service.export(OWNER, null, null, true, "right-pw", false).content();
+
+    assertThrows(
+        InvalidCredentialsException.class,
+        () -> service.importVault(OWNER, blob, "wrong-pw", null, null));
+  }
+
+  @Test
+  void importsPlaintextCsvFromAnotherManagerAndCreatesCategory() {
+    // KeePass-style header (Title/Group) exercises the column-alias mapping.
+    String csv =
+        "Title,Username,Password,URL,Notes,Group\r\n"
+            + "Bank,john,hunter2,https://bank.example,,Finance\r\n";
+    when(categoryRepository.save(any(Category.class)))
+        .thenAnswer(
+            inv -> {
+              Category c = inv.getArgument(0);
+              c.setId(5L);
+              return c;
+            });
+    ArgumentCaptor<PasswordEntry> captor = ArgumentCaptor.forClass(PasswordEntry.class);
+    when(passwordEntryRepository.save(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+    VaultImportResponseDto summary = service.importVault(OWNER, csv, null, null, null);
+
+    assertEquals(1, summary.getImported());
+    assertEquals(1, summary.getCategoriesCreated());
+    PasswordEntry imported = captor.getValue();
+    assertEquals("Bank", imported.getName());
+    assertEquals("hunter2", imported.getPassword());
+    assertEquals("Finance", imported.getCategory().getName());
+  }
+
+  @Test
+  void importSkipsIncompleteRows() {
+    ArgumentCaptor<PasswordEntry> captor = ArgumentCaptor.forClass(PasswordEntry.class);
+    when(passwordEntryRepository.save(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+    String csv = "name,username,password\r\nGitHub,gabriel,\r\nReal,user,pw\r\n";
+    VaultImportResponseDto summary = service.importVault(OWNER, csv, null, null, null);
+
+    assertEquals(1, summary.getImported());
+    assertEquals(1, summary.getSkipped());
+    assertEquals("Real", captor.getValue().getName());
+  }
+
+  @Test
+  void importRejectsUnrecognizedHeader() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> service.importVault(OWNER, "foo,bar\r\n1,2\r\n", null, null, null));
+  }
+}

--- a/backend/src/test/java/com/vaultweb/passwordmanager/backend/support/CsvSupportTest.java
+++ b/backend/src/test/java/com/vaultweb/passwordmanager/backend/support/CsvSupportTest.java
@@ -1,0 +1,60 @@
+package com.vaultweb.passwordmanager.backend.support;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CsvSupportTest {
+
+  @Test
+  void roundTripsSimpleRows() {
+    List<String[]> rows =
+        List.of(
+            new String[] {"name", "username", "password"},
+            new String[] {"GitHub", "gabriel", "s3cr3t"});
+    List<String[]> parsed = CsvSupport.parse(CsvSupport.write(rows));
+    assertEquals(2, parsed.size());
+    assertArrayEquals(new String[] {"name", "username", "password"}, parsed.get(0));
+    assertArrayEquals(new String[] {"GitHub", "gabriel", "s3cr3t"}, parsed.get(1));
+  }
+
+  @Test
+  void roundTripsFieldsWithCommasQuotesAndNewlines() {
+    String[] row = {"a,b", "say \"hi\"", "line1\nline2", ""};
+    List<String[]> parsed = CsvSupport.parse(CsvSupport.write(List.<String[]>of(row)));
+    assertEquals(1, parsed.size());
+    assertArrayEquals(row, parsed.get(0));
+  }
+
+  @Test
+  void quotesFieldsOnlyWhenNeeded() {
+    String csv = CsvSupport.write(List.<String[]>of(new String[] {"plain", "with,comma"}));
+    assertTrue(csv.startsWith("plain,\"with,comma\""));
+  }
+
+  @Test
+  void parsesEscapedQuotes() {
+    List<String[]> parsed = CsvSupport.parse("\"a\"\"b\",c\r\n");
+    assertArrayEquals(new String[] {"a\"b", "c"}, parsed.get(0));
+  }
+
+  @Test
+  void acceptsLfOnlyLineEndings() {
+    List<String[]> parsed = CsvSupport.parse("h1,h2\nv1,v2\n");
+    assertEquals(2, parsed.size());
+    assertArrayEquals(new String[] {"v1", "v2"}, parsed.get(1));
+  }
+
+  @Test
+  void capturesTrailingRowWithoutNewline() {
+    assertArrayEquals(new String[] {"a", "b", "c"}, CsvSupport.parse("a,b,c").get(0));
+  }
+
+  @Test
+  void emptyInputYieldsNoRows() {
+    assertTrue(CsvSupport.parse("").isEmpty());
+  }
+}


### PR DESCRIPTION
## What

Adds vault export and import (#81): `POST /api/vault/export` and `POST /api/vault/import`.

## Behaviour

- **Encrypted by default** — export is a password-protected envelope (AES-GCM, PBKDF2 key derived from a separate *export password*); a plaintext CSV is only produced when explicitly confirmed.
- **Import auto-detects** the encrypted envelope vs. a plaintext CSV.
- **Interoperable** — the CSV uses a standard `name,username,password,url,notes,category` layout, and import maps common headers from other managers (Bitwarden `login_username`/`login_uri`/`folder`, KeePass `Title`/`Group`, …) so a vault can be brought in without hand-editing.
- **Categories** are recreated by name on import.
- Passwords are stored through the existing vault encryption path. The export password is independent of the master password, so an export stays portable across instances.

## Acceptance criteria

- [x] User can export their vault to a standard format (CSV)
- [x] User can import entries from that format
- [x] Encrypted export is the default; plaintext export needs explicit confirmation
- [x] Imported entries land in the right categories where possible

## Notes

- `.kdbx` is intentionally left for a follow-up — the issue lists CSV as an acceptable fallback, and a binary KeePass format is better handled separately.
- The encrypted envelope is `VWENC1:` + base64(`iterations | salt | iv | ciphertext`); a wrong export password is reported distinctly from a corrupt file.

## Tests

Unit tests cover the CSV round-trip (commas, quotes, embedded newlines), the password-based encrypt/decrypt (round-trip, wrong password, malformed envelope), and the full export → import round-trip including category creation and interop headers. The new request DTOs are added to the existing `toString` secrecy test so the export/import passwords never leak into logs.

Closes #81
